### PR TITLE
Fixing the error occured when using negated binary columns with FeatureBinarizer

### DIFF
--- a/aix360/algorithms/rbm/features.py
+++ b/aix360/algorithms/rbm/features.py
@@ -137,7 +137,7 @@ class FeatureBinarizer(TransformerMixin):
             # Constant or binary column
             if c in maps:
                 # Rename values to 0, 1
-                A[(str(c), '', '')] = data[c].map(maps[c])
+                A[(str(c), '', '')] = data[c].map(maps[c]).astype(int)
                 if self.negations:
                     A[(str(c), 'not', '')] = 1 - A[(str(c), '', '')]
 


### PR DESCRIPTION
Issue: #112 

I've just noticed that the FeatureBinarizer, when including the negated columns as well, does not work when using a dataset where there is a binary categorical feature. ~~That's probably another Pandas version error, where the 1.0.0 or newer Pandas versions work significantly different than they previously did.~~ (Got the error using Pandas 0.25.3)

When calling `fb.fit_transform(<dataset_with_binary_category>, negations=True)`
The error message was: **TypeError: unsupported operand type(s) for -: 'int' and 'Categorical'**  
At line 142. in function *transform()*: `A[(str(c), 'not', '')] = 1 - A[(str(c), '', '')]`  
where `A[(str(c), '', '')] = data[c].map(maps[c])` and `c` is a specific column

At that line the substraction does not work, because the Series `A[(str(c), '', '')]` is categorical.

Solution:  
For a solution just convert the type of `A[(str(c), '', '')]` to integer as `A[(str(c), '', '')] = data[c].map(maps[c]).astype(int)`. Although it could be solvable in many formats, I've seen the pattern `astype(int)` elsewhere in the codebase, so I hope that the solution is satisfactory.