### PR TITLE
Specify CVXPY version to use '*' for matrix multiplication

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setuptools.setup(
             'scikit-learn>=0.21.2',
             'torch',
             'torchvision',
-            'cvxpy',
+            'cvxpy==1.0.31',
             'cvxopt',
             'Image',
             'tensorflow==1.14',


### PR DESCRIPTION
`pip install` pulls the latest version of CVXPY, version 1.1.15. Using the the BRCG algorithm with this version results in the following run time warning several times that cannot be filtered.
```
UserWarning: This use of ``*`` has resulted in matrix multiplication.
Using ``*`` for matrix multiplication has been deprecated since CVXPY 1.1.
    Use ``*`` for matrix-scalar and vector-scalar multiplication.
    Use ``@`` for matrix-matrix and matrix-vector multiplication.
    Use ``multiply`` for elementwise multiplication.
 ```
 
Reverting to an older version, by specifying a version in `setup.py` allows for this deprecated use. Assumes CVXPY isn't used by other algorithms in the toolkit.