### PR TITLE
Fixed TRXF Feature evaluation bug

### DIFF
--- a/aix360/algorithms/rule_induction/trxf/core/feature.py
+++ b/aix360/algorithms/rule_induction/trxf/core/feature.py
@@ -52,10 +52,10 @@ class Feature:
         operand_stack = []
         for token in self.reverse_polish_notation:
             if token in OPERATORS:
-                lhs = operand_stack.pop()
-                _validate_number(lhs)
                 rhs = operand_stack.pop()
                 _validate_number(rhs)
+                lhs = operand_stack.pop()
+                _validate_number(lhs)
                 expression = str(lhs) + token + str(rhs)
                 try:
                     operand_stack.append(eval(expression))

--- a/examples/rule_induction/brcg_demo.ipynb
+++ b/examples/rule_induction/brcg_demo.ipynb
@@ -1,0 +1,553 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "from sklearn.metrics import precision_score, recall_score, accuracy_score, balanced_accuracy_score\n",
+    "from aix360.algorithms.rule_induction.rbm.boolean_rule_cg import BooleanRuleCG as BRCG\n",
+    "from aix360.algorithms.rbm import FeatureBinarizer\n",
+    "import time"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Rule Induction using BRCG"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Binary classification with a random 20% test set\n",
+    "\n",
+    "We read the adult dataset from the UCI repository. The goal is to learn a rule describing people who earn more than 50K."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_type = {'age': np.float,\n",
+    "             'workclass': str,\n",
+    "             'fnlwgt': np.float,\n",
+    "             'education': str,\n",
+    "             'education-num': np.float,\n",
+    "             'marital-status': str,\n",
+    "             'occupation': str,\n",
+    "             'relationship': str,\n",
+    "             'race': str,\n",
+    "             'sex': str,\n",
+    "             'capital-gain': np.float,\n",
+    "             'capital-loss': np.float,\n",
+    "             'native-country': str,\n",
+    "             'hours-per-week': np.float,\n",
+    "             'label': str}\n",
+    "\n",
+    "col_names = ['age', 'workclass', 'fnlwgt', 'education',\n",
+    "             'education-num', 'marital-status', 'occupation',\n",
+    "             'relationship', 'race', 'sex',\n",
+    "             'capital-gain', 'capital-loss', 'hours-per-week',\n",
+    "             'native-country', 'label']\n",
+    "\n",
+    "df = pd.read_csv('https://archive.ics.uci.edu/ml/machine-learning-databases/adult/adult.data',\n",
+    "                 header=None,\n",
+    "                 delimiter=', ',\n",
+    "                 engine='python',\n",
+    "                 names=col_names,\n",
+    "                 dtype=data_type)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Comlum names shall not contain whitespace or arithmetic operators (+, -, *, /)\n",
+    "We eventually output the rule set in TRXF format, where compound features are supported by parsing an expression string. So simple features like column names of a data frame must not contain these so that they are parsed as a single variable rather than an expression."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'pandas.core.frame.DataFrame'>\n",
+      "RangeIndex: 32561 entries, 0 to 32560\n",
+      "Data columns (total 15 columns):\n",
+      " #   Column          Non-Null Count  Dtype  \n",
+      "---  ------          --------------  -----  \n",
+      " 0   age             32561 non-null  float64\n",
+      " 1   workclass       32561 non-null  object \n",
+      " 2   fnlwgt          32561 non-null  float64\n",
+      " 3   education       32561 non-null  object \n",
+      " 4   education_num   32561 non-null  float64\n",
+      " 5   marital_status  32561 non-null  object \n",
+      " 6   occupation      32561 non-null  object \n",
+      " 7   relationship    32561 non-null  object \n",
+      " 8   race            32561 non-null  object \n",
+      " 9   sex             32561 non-null  object \n",
+      " 10  capital_gain    32561 non-null  float64\n",
+      " 11  capital_loss    32561 non-null  float64\n",
+      " 12  hours_per_week  32561 non-null  float64\n",
+      " 13  native_country  32561 non-null  object \n",
+      " 14  label           32561 non-null  object \n",
+      "dtypes: float64(6), object(9)\n",
+      "memory usage: 3.7+ MB\n"
+     ]
+    }
+   ],
+   "source": [
+    "df.columns = df.columns.str.replace('-', '_')\n",
+    "df.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    age         workclass    fnlwgt  education  education_num  \\\n",
+      "0  39.0         State-gov   77516.0  Bachelors           13.0   \n",
+      "1  50.0  Self-emp-not-inc   83311.0  Bachelors           13.0   \n",
+      "2  38.0           Private  215646.0    HS-grad            9.0   \n",
+      "3  53.0           Private  234721.0       11th            7.0   \n",
+      "4  28.0           Private  338409.0  Bachelors           13.0   \n",
+      "\n",
+      "       marital_status         occupation   relationship   race     sex  \\\n",
+      "0       Never-married       Adm-clerical  Not-in-family  White    Male   \n",
+      "1  Married-civ-spouse    Exec-managerial        Husband  White    Male   \n",
+      "2            Divorced  Handlers-cleaners  Not-in-family  White    Male   \n",
+      "3  Married-civ-spouse  Handlers-cleaners        Husband  Black    Male   \n",
+      "4  Married-civ-spouse     Prof-specialty           Wife  Black  Female   \n",
+      "\n",
+      "   capital_gain  capital_loss  hours_per_week native_country  label  \n",
+      "0        2174.0           0.0            40.0  United-States  <=50K  \n",
+      "1           0.0           0.0            13.0  United-States  <=50K  \n",
+      "2           0.0           0.0            40.0  United-States  <=50K  \n",
+      "3           0.0           0.0            40.0  United-States  <=50K  \n",
+      "4           0.0           0.0            40.0           Cuba  <=50K  \n"
+     ]
+    }
+   ],
+   "source": [
+    "TARGET_COLUMN = 'label'\n",
+    "print(df.head())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### The rule induction trains for specific 'foreground' aka 'positive' value of the target label, which we set to '>50K' below. This means that the rule set will characterize the set of adults who earn more than 50K)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Positive value >50K occurs 7841 times.\n",
+      "<=50K    24720\n",
+      ">50K      7841\n",
+      "Name: label, dtype: int64\n"
+     ]
+    }
+   ],
+   "source": [
+    "POS_VALUE = '>50K' # Setting positive value of the label for which we train\n",
+    "values_dist = df[TARGET_COLUMN].value_counts()\n",
+    "print('Positive value {} occurs {} times.'.format(POS_VALUE,values_dist[POS_VALUE]))\n",
+    "print(values_dist)\n",
+    "# This is distribution of the two values of the target label"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Train-test split and encode labels as integers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Training set:\n",
+      "<=50K    19778\n",
+      ">50K      6270\n",
+      "Name: label, dtype: int64\n",
+      "Test set:\n",
+      "<=50K    4942\n",
+      ">50K     1571\n",
+      "Name: label, dtype: int64\n"
+     ]
+    }
+   ],
+   "source": [
+    "train, test = train_test_split(df, test_size=0.2, random_state=42)\n",
+    "# Split the data set into 80% training and 20% test set\n",
+    "print('Training set:')\n",
+    "print(train[TARGET_COLUMN].value_counts())\n",
+    "print('Test set:')\n",
+    "print(test[TARGET_COLUMN].value_counts())\n",
+    "\n",
+    "y_train = train[TARGET_COLUMN].apply(lambda x: 1 if x == POS_VALUE else 0)\n",
+    "x_train = train.drop(columns=[TARGET_COLUMN])\n",
+    "\n",
+    "y_test = test[TARGET_COLUMN].apply(lambda x: 1 if x == POS_VALUE else 0)\n",
+    "x_test = test.drop(columns=[TARGET_COLUMN])\n",
+    "# Split data frames into features and label"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Instantiate the BRCG explainer and train it using default parameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/Caskroom/miniconda/base/envs/aix360/lib/python3.6/site-packages/cvxpy/expressions/expression.py:593: UserWarning: \n",
+      "This use of ``*`` has resulted in matrix multiplication.\n",
+      "Using ``*`` for matrix multiplication has been deprecated since CVXPY 1.1.\n",
+      "    Use ``*`` for matrix-scalar and vector-scalar multiplication.\n",
+      "    Use ``@`` for matrix-matrix and matrix-vector multiplication.\n",
+      "    Use ``multiply`` for elementwise multiplication.\n",
+      "This code path has been hit 1 times so far.\n",
+      "\n",
+      "  warnings.warn(msg, UserWarning)\n",
+      "/usr/local/Caskroom/miniconda/base/envs/aix360/lib/python3.6/site-packages/cvxpy/expressions/expression.py:593: UserWarning: \n",
+      "This use of ``*`` has resulted in matrix multiplication.\n",
+      "Using ``*`` for matrix multiplication has been deprecated since CVXPY 1.1.\n",
+      "    Use ``*`` for matrix-scalar and vector-scalar multiplication.\n",
+      "    Use ``@`` for matrix-matrix and matrix-vector multiplication.\n",
+      "    Use ``multiply`` for elementwise multiplication.\n",
+      "This code path has been hit 2 times so far.\n",
+      "\n",
+      "  warnings.warn(msg, UserWarning)\n",
+      "/usr/local/Caskroom/miniconda/base/envs/aix360/lib/python3.6/site-packages/cvxpy/expressions/expression.py:593: UserWarning: \n",
+      "This use of ``*`` has resulted in matrix multiplication.\n",
+      "Using ``*`` for matrix multiplication has been deprecated since CVXPY 1.1.\n",
+      "    Use ``*`` for matrix-scalar and vector-scalar multiplication.\n",
+      "    Use ``@`` for matrix-matrix and matrix-vector multiplication.\n",
+      "    Use ``multiply`` for elementwise multiplication.\n",
+      "This code path has been hit 3 times so far.\n",
+      "\n",
+      "  warnings.warn(msg, UserWarning)\n",
+      "/usr/local/Caskroom/miniconda/base/envs/aix360/lib/python3.6/site-packages/cvxpy/expressions/expression.py:593: UserWarning: \n",
+      "This use of ``*`` has resulted in matrix multiplication.\n",
+      "Using ``*`` for matrix multiplication has been deprecated since CVXPY 1.1.\n",
+      "    Use ``*`` for matrix-scalar and vector-scalar multiplication.\n",
+      "    Use ``@`` for matrix-matrix and matrix-vector multiplication.\n",
+      "    Use ``multiply`` for elementwise multiplication.\n",
+      "This code path has been hit 4 times so far.\n",
+      "\n",
+      "  warnings.warn(msg, UserWarning)\n",
+      "/usr/local/Caskroom/miniconda/base/envs/aix360/lib/python3.6/site-packages/cvxpy/expressions/expression.py:593: UserWarning: \n",
+      "This use of ``*`` has resulted in matrix multiplication.\n",
+      "Using ``*`` for matrix multiplication has been deprecated since CVXPY 1.1.\n",
+      "    Use ``*`` for matrix-scalar and vector-scalar multiplication.\n",
+      "    Use ``@`` for matrix-matrix and matrix-vector multiplication.\n",
+      "    Use ``multiply`` for elementwise multiplication.\n",
+      "This code path has been hit 5 times so far.\n",
+      "\n",
+      "  warnings.warn(msg, UserWarning)\n",
+      "/usr/local/Caskroom/miniconda/base/envs/aix360/lib/python3.6/site-packages/cvxpy/expressions/expression.py:593: UserWarning: \n",
+      "This use of ``*`` has resulted in matrix multiplication.\n",
+      "Using ``*`` for matrix multiplication has been deprecated since CVXPY 1.1.\n",
+      "    Use ``*`` for matrix-scalar and vector-scalar multiplication.\n",
+      "    Use ``@`` for matrix-matrix and matrix-vector multiplication.\n",
+      "    Use ``multiply`` for elementwise multiplication.\n",
+      "This code path has been hit 6 times so far.\n",
+      "\n",
+      "  warnings.warn(msg, UserWarning)\n",
+      "/usr/local/Caskroom/miniconda/base/envs/aix360/lib/python3.6/site-packages/cvxpy/expressions/expression.py:593: UserWarning: \n",
+      "This use of ``*`` has resulted in matrix multiplication.\n",
+      "Using ``*`` for matrix multiplication has been deprecated since CVXPY 1.1.\n",
+      "    Use ``*`` for matrix-scalar and vector-scalar multiplication.\n",
+      "    Use ``@`` for matrix-matrix and matrix-vector multiplication.\n",
+      "    Use ``multiply`` for elementwise multiplication.\n",
+      "This code path has been hit 7 times so far.\n",
+      "\n",
+      "  warnings.warn(msg, UserWarning)\n",
+      "/usr/local/Caskroom/miniconda/base/envs/aix360/lib/python3.6/site-packages/cvxpy/expressions/expression.py:593: UserWarning: \n",
+      "This use of ``*`` has resulted in matrix multiplication.\n",
+      "Using ``*`` for matrix multiplication has been deprecated since CVXPY 1.1.\n",
+      "    Use ``*`` for matrix-scalar and vector-scalar multiplication.\n",
+      "    Use ``@`` for matrix-matrix and matrix-vector multiplication.\n",
+      "    Use ``multiply`` for elementwise multiplication.\n",
+      "This code path has been hit 8 times so far.\n",
+      "\n",
+      "  warnings.warn(msg, UserWarning)\n",
+      "/usr/local/Caskroom/miniconda/base/envs/aix360/lib/python3.6/site-packages/cvxpy/expressions/expression.py:593: UserWarning: \n",
+      "This use of ``*`` has resulted in matrix multiplication.\n",
+      "Using ``*`` for matrix multiplication has been deprecated since CVXPY 1.1.\n",
+      "    Use ``*`` for matrix-scalar and vector-scalar multiplication.\n",
+      "    Use ``@`` for matrix-matrix and matrix-vector multiplication.\n",
+      "    Use ``multiply`` for elementwise multiplication.\n",
+      "This code path has been hit 9 times so far.\n",
+      "\n",
+      "  warnings.warn(msg, UserWarning)\n",
+      "/usr/local/Caskroom/miniconda/base/envs/aix360/lib/python3.6/site-packages/cvxpy/expressions/expression.py:593: UserWarning: \n",
+      "This use of ``*`` has resulted in matrix multiplication.\n",
+      "Using ``*`` for matrix multiplication has been deprecated since CVXPY 1.1.\n",
+      "    Use ``*`` for matrix-scalar and vector-scalar multiplication.\n",
+      "    Use ``@`` for matrix-matrix and matrix-vector multiplication.\n",
+      "    Use ``multiply`` for elementwise multiplication.\n",
+      "This code path has been hit 10 times so far.\n",
+      "\n",
+      "  warnings.warn(msg, UserWarning)\n",
+      "/usr/local/Caskroom/miniconda/base/envs/aix360/lib/python3.6/site-packages/cvxpy/expressions/expression.py:593: UserWarning: \n",
+      "This use of ``*`` has resulted in matrix multiplication.\n",
+      "Using ``*`` for matrix multiplication has been deprecated since CVXPY 1.1.\n",
+      "    Use ``*`` for matrix-scalar and vector-scalar multiplication.\n",
+      "    Use ``@`` for matrix-matrix and matrix-vector multiplication.\n",
+      "    Use ``multiply`` for elementwise multiplication.\n",
+      "This code path has been hit 11 times so far.\n",
+      "\n",
+      "  warnings.warn(msg, UserWarning)\n",
+      "/usr/local/Caskroom/miniconda/base/envs/aix360/lib/python3.6/site-packages/cvxpy/expressions/expression.py:593: UserWarning: \n",
+      "This use of ``*`` has resulted in matrix multiplication.\n",
+      "Using ``*`` for matrix multiplication has been deprecated since CVXPY 1.1.\n",
+      "    Use ``*`` for matrix-scalar and vector-scalar multiplication.\n",
+      "    Use ``@`` for matrix-matrix and matrix-vector multiplication.\n",
+      "    Use ``multiply`` for elementwise multiplication.\n",
+      "This code path has been hit 12 times so far.\n",
+      "\n",
+      "  warnings.warn(msg, UserWarning)\n",
+      "/usr/local/Caskroom/miniconda/base/envs/aix360/lib/python3.6/site-packages/cvxpy/expressions/expression.py:593: UserWarning: \n",
+      "This use of ``*`` has resulted in matrix multiplication.\n",
+      "Using ``*`` for matrix multiplication has been deprecated since CVXPY 1.1.\n",
+      "    Use ``*`` for matrix-scalar and vector-scalar multiplication.\n",
+      "    Use ``@`` for matrix-matrix and matrix-vector multiplication.\n",
+      "    Use ``multiply`` for elementwise multiplication.\n",
+      "This code path has been hit 13 times so far.\n",
+      "\n",
+      "  warnings.warn(msg, UserWarning)\n",
+      "/usr/local/Caskroom/miniconda/base/envs/aix360/lib/python3.6/site-packages/cvxpy/expressions/expression.py:593: UserWarning: \n",
+      "This use of ``*`` has resulted in matrix multiplication.\n",
+      "Using ``*`` for matrix multiplication has been deprecated since CVXPY 1.1.\n",
+      "    Use ``*`` for matrix-scalar and vector-scalar multiplication.\n",
+      "    Use ``@`` for matrix-matrix and matrix-vector multiplication.\n",
+      "    Use ``multiply`` for elementwise multiplication.\n",
+      "This code path has been hit 14 times so far.\n",
+      "\n",
+      "  warnings.warn(msg, UserWarning)\n",
+      "/usr/local/Caskroom/miniconda/base/envs/aix360/lib/python3.6/site-packages/cvxpy/expressions/expression.py:593: UserWarning: \n",
+      "This use of ``*`` has resulted in matrix multiplication.\n",
+      "Using ``*`` for matrix multiplication has been deprecated since CVXPY 1.1.\n",
+      "    Use ``*`` for matrix-scalar and vector-scalar multiplication.\n",
+      "    Use ``@`` for matrix-matrix and matrix-vector multiplication.\n",
+      "    Use ``multiply`` for elementwise multiplication.\n",
+      "This code path has been hit 15 times so far.\n",
+      "\n",
+      "  warnings.warn(msg, UserWarning)\n",
+      "/usr/local/Caskroom/miniconda/base/envs/aix360/lib/python3.6/site-packages/cvxpy/expressions/expression.py:593: UserWarning: \n",
+      "This use of ``*`` has resulted in matrix multiplication.\n",
+      "Using ``*`` for matrix multiplication has been deprecated since CVXPY 1.1.\n",
+      "    Use ``*`` for matrix-scalar and vector-scalar multiplication.\n",
+      "    Use ``@`` for matrix-matrix and matrix-vector multiplication.\n",
+      "    Use ``multiply`` for elementwise multiplication.\n",
+      "This code path has been hit 16 times so far.\n",
+      "\n",
+      "  warnings.warn(msg, UserWarning)\n",
+      "/usr/local/Caskroom/miniconda/base/envs/aix360/lib/python3.6/site-packages/cvxpy/expressions/expression.py:593: UserWarning: \n",
+      "This use of ``*`` has resulted in matrix multiplication.\n",
+      "Using ``*`` for matrix multiplication has been deprecated since CVXPY 1.1.\n",
+      "    Use ``*`` for matrix-scalar and vector-scalar multiplication.\n",
+      "    Use ``@`` for matrix-matrix and matrix-vector multiplication.\n",
+      "    Use ``multiply`` for elementwise multiplication.\n",
+      "This code path has been hit 17 times so far.\n",
+      "\n",
+      "  warnings.warn(msg, UserWarning)\n",
+      "/usr/local/Caskroom/miniconda/base/envs/aix360/lib/python3.6/site-packages/cvxpy/expressions/expression.py:593: UserWarning: \n",
+      "This use of ``*`` has resulted in matrix multiplication.\n",
+      "Using ``*`` for matrix multiplication has been deprecated since CVXPY 1.1.\n",
+      "    Use ``*`` for matrix-scalar and vector-scalar multiplication.\n",
+      "    Use ``@`` for matrix-matrix and matrix-vector multiplication.\n",
+      "    Use ``multiply`` for elementwise multiplication.\n",
+      "This code path has been hit 18 times so far.\n",
+      "\n",
+      "  warnings.warn(msg, UserWarning)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Training time (sec): 47.28401708602905\n",
+      "Accuracy: 0.8211269768155995\n",
+      "Balanced accuracy: 0.7253901463211316\n",
+      "Precision: 0.6571207430340558\n",
+      "Recall: 0.5404201145767027\n"
+     ]
+    }
+   ],
+   "source": [
+    "fb = FeatureBinarizer(negations=True)\n",
+    "X_train_fb = fb.fit_transform(x_train)\n",
+    "x_test_fb = fb.transform(x_test)\n",
+    "\n",
+    "explainer = BRCG(silent=True)\n",
+    "start_time = time.time()\n",
+    "explainer.fit(X_train_fb, y_train)\n",
+    "end_time = time.time()\n",
+    "print('Training time (sec): ' + str(end_time - start_time))\n",
+    "\n",
+    "# compute performance metrics on test set\n",
+    "y_pred = explainer.predict(x_test_fb)\n",
+    "\n",
+    "print('Accuracy:', accuracy_score(y_test, y_pred))\n",
+    "print('Balanced accuracy:', balanced_accuracy_score(y_test, y_pred))\n",
+    "print('Precision:', precision_score(y_test, y_pred, pos_label=1))\n",
+    "print('Recall:', recall_score(y_test, y_pred, pos_label=1))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Extract the rule set"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "if\n",
+      "([age > 26.0] ^ [education_num > 9.0] ^ [marital_status == Married-civ-spouse] ^ [occupation != Craft-repair] ^ [occupation != Farming-fishing] ^ [occupation != Handlers-cleaners] ^ [occupation != Other-service])\n",
+      "then\n",
+      "1\n"
+     ]
+    }
+   ],
+   "source": [
+    "trxf_ruleset = explainer.explain()\n",
+    "print(str(trxf_ruleset))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Export the resulting ruleset to a PMML file\n",
+    "### Construct a RuleSetClassifier object\n",
+    "A rule set by itself is merely a description of the given concept/target. Therefore, to use rule sets for a binary classification task, we must specify how to deal with potential overlaps between rule sets. For example, we could have learned 2 rule sets: one for >50K and another for <=50K. For instances where both rule sets are triggered, how do we classify that instance? There are 3 rule selection methods supported in PMML: First Hit, Weighted Sum, and Weighted Max. See here for more info: https://dmg.org/pmml/v4-4/RuleSet.html#xsdElement_RuleSelectionMethod. If we only learn a rule set for a single label, we can set a default label to which instances will be classified when the learned rule set does not trigger. \n",
+    "\n",
+    "In our case, since we only learn a rule set for a single label and use the default label for the rest, all 3 rule selection methods will have the same effect. However, if a rule selection method other than FirstHit is chosen, we need to compute the weights and confidence values for each rule."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import aix360.algorithms.rule_induction.trxf.classifier.ruleset_classifier as trxf_classifier\n",
+    "import aix360.algorithms.rule_induction.trxf.pmml_export as pmml\n",
+    "classifier = trxf_classifier.RuleSetClassifier([trxf_ruleset],\n",
+    "                                               rule_selection_method=trxf_classifier.RuleSelectionMethod.WEIGHTED_MAX,\n",
+    "                                               confidence_metric=trxf_classifier.ConfidenceMetric.LAPLACE,\n",
+    "                                               weight_metric=trxf_classifier.WeightMetric.CONFIDENCE,\n",
+    "                                               default_label='<=50K')\n",
+    "classifier.update_rules_with_metrics(x_test, y_test)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Export the TRXF classifier to a PMML document"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "reader = pmml.TrxfReader()\n",
+    "reader.load_data_dictionary(x_test)\n",
+    "serializer = pmml.NyokaSerializer()\n",
+    "exporter = pmml.PmmlExporter(reader, serializer)\n",
+    "with open(\"adult_weighted_max_brcg.pmml\", \"w\") as text_file:\n",
+    "    text_file.write(exporter.export(classifier))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "interpreter": {
+   "hash": "aee8b7b246df8f9039afb4144a1f6fd8d2ca17a180786b69acc140d282b71a49"
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.13"
+  },
+  "metadata": {
+   "interpreter": {
+    "hash": "e534e48711db4d1e1c48977d0d14ff85b1f16d41bcc4fdfd88268a329b3c9d66"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/tests/rule_induction/trxf/core/test_feature.py
+++ b/tests/rule_induction/trxf/core/test_feature.py
@@ -14,13 +14,13 @@ class TestFeature(TestCase):
     def test_evaluate_numerical(self):
         feature = Feature('   5 +x1 *    (4-x2)')
         actual = feature.evaluate({'x1': 6.3, 'x2': 3.1})
-        expected = -0.67
+        expected = 5 + 6.3 * (4 - 3.1)
         self.assertAlmostEqual(actual, expected)
 
     def test_evaluate_numerical_starts_with_unary_minus(self):
         feature = Feature('   -x1 *    (4-x2)')
         actual = feature.evaluate({'x1': 6.3, 'x2': 3.1})
-        expected = -5.67
+        expected = -6.3 * (4 - 3.1)
         self.assertAlmostEqual(actual, expected)
 
     def test_evaluate_illegal_assignment_should_raise(self):


### PR DESCRIPTION
Problem: In the evaluation of the postfix representation, the stack was
popped in the wrong order for the lhs and rhs operands. So the result
was wrong for non-commutative operators.

Solution: Popped the stack in the correct order.

Testing: Corrected unit tests that failed to catch the bug.
Signed-off-by: Yusik Kim <kmyusk@gmail.com>