### PR TITLE
PMML export enhancements and 3.8-3.6 compatibility of rule induction code

### DIFF
--- a/aix360/algorithms/rule_induction/trxf/pmml_export/models/data_dictionary.py
+++ b/aix360/algorithms/rule_induction/trxf/pmml_export/models/data_dictionary.py
@@ -24,10 +24,16 @@ class OpType(enum.Enum):
 
 
 @dataclass(frozen=True)
+class Value:
+    value: str = field()
+
+
+@dataclass(frozen=True)
 class DataField:
     name: str = field()
     optype: OpType = field()
     dataType: DataType = field()
+    values: typing.Optional[typing.List[Value]] = field(default=None)
 
 
 @dataclass(frozen=True)

--- a/aix360/algorithms/rule_induction/trxf/pmml_export/serializer/nyoka_serializer.py
+++ b/aix360/algorithms/rule_induction/trxf/pmml_export/serializer/nyoka_serializer.py
@@ -41,7 +41,10 @@ class NyokaSerializer(AbstractSerializer):
         return nyoka_pmml.DataDictionary(
             numberOfFields=0 if data_dictionary.dataFields is None else len(data_dictionary.dataFields),
             DataField=None if data_dictionary.dataFields is None else [
-                nyoka_pmml.DataField(name=f.name, optype=f.optype.name, dataType=f.dataType.name)
+                nyoka_pmml.DataField(name=f.name, optype=f.optype.name, dataType=f.dataType.name,
+                                     Value=None if f.values is None else [
+                                         nyoka_pmml.Value(value=v.value) for v in f.values
+                                     ])
                 for f in data_dictionary.dataFields])
 
     def _nyoka_rule_set_model(self, rule_set_model: models.RuleSetModel) -> nyoka_pmml.RuleSetModel:

--- a/tests/rule_induction/trxf/pmml_export/resources/adult.pmml
+++ b/tests/rule_induction/trxf/pmml_export/resources/adult.pmml
@@ -6,104 +6,295 @@
     </Header>
     <DataDictionary numberOfFields="14">
         <DataField name="age" optype="continuous" dataType="double"/>
-        <DataField name="workclass" optype="categorical" dataType="string"/>
+        <DataField name="workclass" optype="categorical" dataType="string">
+            <Value value="Private"/>
+            <Value value="State-gov"/>
+            <Value value="Self-emp-not-inc"/>
+            <Value value="Local-gov"/>
+            <Value value="Federal-gov"/>
+            <Value value="Self-emp-inc"/>
+            <Value value="Without-pay"/>
+        </DataField>
         <DataField name="fnlwgt" optype="continuous" dataType="double"/>
-        <DataField name="education" optype="categorical" dataType="string"/>
+        <DataField name="education" optype="categorical" dataType="string">
+            <Value value="HS-grad"/>
+            <Value value="10th"/>
+            <Value value="Bachelors"/>
+            <Value value="Assoc-acdm"/>
+            <Value value="Some-college"/>
+            <Value value="Doctorate"/>
+            <Value value="Prof-school"/>
+            <Value value="9th"/>
+            <Value value="Assoc-voc"/>
+            <Value value="Masters"/>
+            <Value value="7th-8th"/>
+            <Value value="11th"/>
+            <Value value="1st-4th"/>
+            <Value value="5th-6th"/>
+            <Value value="12th"/>
+            <Value value="Preschool"/>
+        </DataField>
         <DataField name="education_num" optype="continuous" dataType="double"/>
-        <DataField name="marital_status" optype="categorical" dataType="string"/>
-        <DataField name="occupation" optype="categorical" dataType="string"/>
-        <DataField name="relationship" optype="categorical" dataType="string"/>
-        <DataField name="race" optype="categorical" dataType="string"/>
-        <DataField name="sex" optype="categorical" dataType="string"/>
+        <DataField name="marital_status" optype="categorical" dataType="string">
+            <Value value="Married-civ-spouse"/>
+            <Value value="Divorced"/>
+            <Value value="Never-married"/>
+            <Value value="Widowed"/>
+            <Value value="Separated"/>
+            <Value value="Married-spouse-absent"/>
+            <Value value="Married-AF-spouse"/>
+        </DataField>
+        <DataField name="occupation" optype="categorical" dataType="string">
+            <Value value="Transport-moving"/>
+            <Value value="Craft-repair"/>
+            <Value value="Sales"/>
+            <Value value="Adm-clerical"/>
+            <Value value="Prof-specialty"/>
+            <Value value="Other-service"/>
+            <Value value="Exec-managerial"/>
+            <Value value="Farming-fishing"/>
+            <Value value="Machine-op-inspct"/>
+            <Value value="Handlers-cleaners"/>
+            <Value value="Protective-serv"/>
+            <Value value="Tech-support"/>
+            <Value value="Priv-house-serv"/>
+            <Value value="Armed-Forces"/>
+        </DataField>
+        <DataField name="relationship" optype="categorical" dataType="string">
+            <Value value="Husband"/>
+            <Value value="Not-in-family"/>
+            <Value value="Wife"/>
+            <Value value="Own-child"/>
+            <Value value="Unmarried"/>
+            <Value value="Other-relative"/>
+        </DataField>
+        <DataField name="race" optype="categorical" dataType="string">
+            <Value value="White"/>
+            <Value value="Black"/>
+            <Value value="Other"/>
+            <Value value="Asian-Pac-Islander"/>
+            <Value value="Amer-Indian-Eskimo"/>
+        </DataField>
+        <DataField name="sex" optype="categorical" dataType="string">
+            <Value value="Male"/>
+            <Value value="Female"/>
+        </DataField>
         <DataField name="capital_gain" optype="continuous" dataType="double"/>
         <DataField name="capital_loss" optype="continuous" dataType="double"/>
         <DataField name="hours_per_week" optype="continuous" dataType="double"/>
-        <DataField name="native_country" optype="categorical" dataType="string"/>
+        <DataField name="native_country" optype="categorical" dataType="string">
+            <Value value="United-States"/>
+            <Value value="Portugal"/>
+            <Value value="Cuba"/>
+            <Value value="Mexico"/>
+            <Value value="France"/>
+            <Value value="Jamaica"/>
+            <Value value="Haiti"/>
+            <Value value="Honduras"/>
+            <Value value="India"/>
+            <Value value="Dominican-Republic"/>
+            <Value value="Outlying-US(Guam-USVI-etc)"/>
+            <Value value="South"/>
+            <Value value="Scotland"/>
+            <Value value="Italy"/>
+            <Value value="Germany"/>
+            <Value value="Philippines"/>
+            <Value value="Vietnam"/>
+            <Value value="El-Salvador"/>
+            <Value value="Nicaragua"/>
+            <Value value="China"/>
+            <Value value="Trinadad&amp;Tobago"/>
+            <Value value="Puerto-Rico"/>
+            <Value value="Japan"/>
+            <Value value="Iran"/>
+            <Value value="Guatemala"/>
+            <Value value="England"/>
+            <Value value="Poland"/>
+            <Value value="Canada"/>
+            <Value value="Cambodia"/>
+            <Value value="Greece"/>
+            <Value value="Thailand"/>
+            <Value value="Ireland"/>
+            <Value value="Hong"/>
+            <Value value="Taiwan"/>
+            <Value value="Ecuador"/>
+            <Value value="Peru"/>
+            <Value value="Yugoslavia"/>
+            <Value value="Columbia"/>
+            <Value value="Hungary"/>
+            <Value value="Laos"/>
+            <Value value="Holand-Netherlands"/>
+        </DataField>
     </DataDictionary>
     <RuleSetModel functionName="classification" algorithmName="RuleSet">
         <MiningSchema>
             <MiningField name="marital_status" usageType="active"/>
             <MiningField name="education_num" usageType="active"/>
-            <MiningField name="hours_per_week" usageType="active"/>
-            <MiningField name="education" usageType="active"/>
             <MiningField name="age" usageType="active"/>
-            <MiningField name="occupation" usageType="active"/>
+            <MiningField name="education" usageType="active"/>
             <MiningField name="fnlwgt" usageType="active"/>
-            <MiningField name="capital_gain" usageType="active"/>
+            <MiningField name="occupation" usageType="active"/>
             <MiningField name="capital_loss" usageType="active"/>
+            <MiningField name="hours_per_week" usageType="active"/>
+            <MiningField name="workclass" usageType="active"/>
+            <MiningField name="relationship" usageType="active"/>
+            <MiningField name="capital_gain" usageType="active"/>
         </MiningSchema>
         <RuleSet defaultScore="&lt;=50K">
             <RuleSelectionMethod criterion="weightedMax"/>
-            <SimpleRule id="[marital_status == Married-civ-spouse] ^ [education_num &lt;= 12.0] ^ [education_num &gt;= 8.0] ^ [hours_per_week &gt;= 38.0] ^ [education == Some-college] ^ [age &lt;= 57.0] ^ [hours_per_week &lt;= 45.0] ^ [age &gt;= 48.0]" score="&gt;50K" recordCount="15081" nbCorrect="11329" confidence="0.609271523178808" weight="0.609271523178808">
+            <SimpleRule id="[marital_status == Married-civ-spouse] ^ [education_num &gt;= 9.0] ^ [age &gt;= 31.0] ^ [education == Some-college] ^ [fnlwgt &lt;= 255675.0] ^ [occupation == Tech-support]" score="&gt;50K" recordCount="15081" nbCorrect="11305" confidence="0.6956521739130435" weight="0.6956521739130435">
                 <CompoundPredicate booleanOperator="and">
                     <SimplePredicate field="marital_status" operator="equal" value="Married-civ-spouse"/>
-                    <SimplePredicate field="education_num" operator="lessOrEqual" value="12.0"/>
-                    <SimplePredicate field="education_num" operator="greaterOrEqual" value="8.0"/>
-                    <SimplePredicate field="hours_per_week" operator="greaterOrEqual" value="38.0"/>
+                    <SimplePredicate field="education_num" operator="greaterOrEqual" value="9.0"/>
+                    <SimplePredicate field="age" operator="greaterOrEqual" value="31.0"/>
                     <SimplePredicate field="education" operator="equal" value="Some-college"/>
-                    <SimplePredicate field="age" operator="lessOrEqual" value="57.0"/>
-                    <SimplePredicate field="hours_per_week" operator="lessOrEqual" value="45.0"/>
-                    <SimplePredicate field="age" operator="greaterOrEqual" value="48.0"/>
-                </CompoundPredicate>
-            </SimpleRule>
-            <SimpleRule id="[marital_status == Married-civ-spouse] ^ [education_num &lt;= 12.0] ^ [age &gt;= 37.0] ^ [occupation == Tech-support]" score="&gt;50K" recordCount="15081" nbCorrect="11323" confidence="0.684931506849315" weight="0.684931506849315">
-                <CompoundPredicate booleanOperator="and">
-                    <SimplePredicate field="marital_status" operator="equal" value="Married-civ-spouse"/>
-                    <SimplePredicate field="education_num" operator="lessOrEqual" value="12.0"/>
-                    <SimplePredicate field="age" operator="greaterOrEqual" value="37.0"/>
+                    <SimplePredicate field="fnlwgt" operator="lessOrEqual" value="255675.0"/>
                     <SimplePredicate field="occupation" operator="equal" value="Tech-support"/>
                 </CompoundPredicate>
             </SimpleRule>
-            <SimpleRule id="[marital_status == Married-civ-spouse] ^ [education_num &lt;= 12.0] ^ [education_num &gt;= 9.0] ^ [hours_per_week &gt;= 40.0] ^ [age &gt;= 42.0] ^ [education == HS-grad] ^ [age &lt;= 53.0] ^ [fnlwgt &gt;= 154227.0] ^ [fnlwgt &lt;= 163948.0]" score="&gt;50K" recordCount="15081" nbCorrect="11287" confidence="0.3448275862068966" weight="0.3448275862068966">
+            <SimpleRule id="[marital_status == Married-civ-spouse] ^ [education_num &gt;= 13.0] ^ [capital_loss &gt;= 1741.0] ^ [capital_loss &lt;= 1977.0]" score="&gt;50K" recordCount="15081" nbCorrect="11448" confidence="0.9871794871794872" weight="0.9871794871794872">
                 <CompoundPredicate booleanOperator="and">
                     <SimplePredicate field="marital_status" operator="equal" value="Married-civ-spouse"/>
-                    <SimplePredicate field="education_num" operator="lessOrEqual" value="12.0"/>
-                    <SimplePredicate field="education_num" operator="greaterOrEqual" value="9.0"/>
-                    <SimplePredicate field="hours_per_week" operator="greaterOrEqual" value="40.0"/>
-                    <SimplePredicate field="age" operator="greaterOrEqual" value="42.0"/>
-                    <SimplePredicate field="education" operator="equal" value="HS-grad"/>
-                    <SimplePredicate field="age" operator="lessOrEqual" value="53.0"/>
-                    <SimplePredicate field="fnlwgt" operator="greaterOrEqual" value="154227.0"/>
-                    <SimplePredicate field="fnlwgt" operator="lessOrEqual" value="163948.0"/>
+                    <SimplePredicate field="education_num" operator="greaterOrEqual" value="13.0"/>
+                    <SimplePredicate field="capital_loss" operator="greaterOrEqual" value="1741.0"/>
+                    <SimplePredicate field="capital_loss" operator="lessOrEqual" value="1977.0"/>
                 </CompoundPredicate>
             </SimpleRule>
-            <SimpleRule id="[marital_status == Married-civ-spouse] ^ [age &gt;= 37.0] ^ [education_num &lt;= 12.0] ^ [age &lt;= 47.0] ^ [education_num &gt;= 10.0] ^ [occupation == Sales] ^ [fnlwgt &gt;= 131827.0]" score="&gt;50K" recordCount="15081" nbCorrect="11300" confidence="0.5333333333333333" weight="0.5333333333333333">
+            <SimpleRule id="[marital_status == Married-civ-spouse] ^ [education_num &gt;= 12.0] ^ [hours_per_week &gt;= 41.0]" score="&gt;50K" recordCount="15081" nbCorrect="11913" confidence="0.7634500426985482" weight="0.7634500426985482">
+                <CompoundPredicate booleanOperator="and">
+                    <SimplePredicate field="marital_status" operator="equal" value="Married-civ-spouse"/>
+                    <SimplePredicate field="education_num" operator="greaterOrEqual" value="12.0"/>
+                    <SimplePredicate field="hours_per_week" operator="greaterOrEqual" value="41.0"/>
+                </CompoundPredicate>
+            </SimpleRule>
+            <SimpleRule id="[marital_status == Married-civ-spouse] ^ [education == Some-college] ^ [age &lt;= 65.0] ^ [age &gt;= 54.0] ^ [hours_per_week &lt;= 48.0] ^ [fnlwgt &gt;= 193042.0] ^ [fnlwgt &lt;= 220187.0]" score="&gt;50K" recordCount="15081" nbCorrect="11292" confidence="0.35714285714285715" weight="0.35714285714285715">
+                <CompoundPredicate booleanOperator="and">
+                    <SimplePredicate field="marital_status" operator="equal" value="Married-civ-spouse"/>
+                    <SimplePredicate field="education" operator="equal" value="Some-college"/>
+                    <SimplePredicate field="age" operator="lessOrEqual" value="65.0"/>
+                    <SimplePredicate field="age" operator="greaterOrEqual" value="54.0"/>
+                    <SimplePredicate field="hours_per_week" operator="lessOrEqual" value="48.0"/>
+                    <SimplePredicate field="fnlwgt" operator="greaterOrEqual" value="193042.0"/>
+                    <SimplePredicate field="fnlwgt" operator="lessOrEqual" value="220187.0"/>
+                </CompoundPredicate>
+            </SimpleRule>
+            <SimpleRule id="[marital_status == Married-civ-spouse] ^ [education_num &gt;= 15.0]" score="&gt;50K" recordCount="15081" nbCorrect="11508" confidence="0.8354430379746836" weight="0.8354430379746836">
+                <CompoundPredicate booleanOperator="and">
+                    <SimplePredicate field="marital_status" operator="equal" value="Married-civ-spouse"/>
+                    <SimplePredicate field="education_num" operator="greaterOrEqual" value="15.0"/>
+                </CompoundPredicate>
+            </SimpleRule>
+            <SimpleRule id="[marital_status == Married-civ-spouse] ^ [age &gt;= 37.0] ^ [education_num &lt;= 11.0] ^ [education_num &gt;= 10.0] ^ [capital_loss &gt;= 1741.0]" score="&gt;50K" recordCount="15081" nbCorrect="11333" confidence="0.8490566037735849" weight="0.8490566037735849">
+                <CompoundPredicate booleanOperator="and">
+                    <SimplePredicate field="marital_status" operator="equal" value="Married-civ-spouse"/>
+                    <SimplePredicate field="age" operator="greaterOrEqual" value="37.0"/>
+                    <SimplePredicate field="education_num" operator="lessOrEqual" value="11.0"/>
+                    <SimplePredicate field="education_num" operator="greaterOrEqual" value="10.0"/>
+                    <SimplePredicate field="capital_loss" operator="greaterOrEqual" value="1741.0"/>
+                </CompoundPredicate>
+            </SimpleRule>
+            <SimpleRule id="[marital_status == Married-civ-spouse] ^ [education_num &gt;= 8.0] ^ [education_num &lt;= 12.0] ^ [age &gt;= 42.0] ^ [workclass == Federal-gov] ^ [fnlwgt &lt;= 293196.0] ^ [fnlwgt &gt;= 211128.0]" score="&gt;50K" recordCount="15081" nbCorrect="11305" confidence="0.8461538461538461" weight="0.8461538461538461">
+                <CompoundPredicate booleanOperator="and">
+                    <SimplePredicate field="marital_status" operator="equal" value="Married-civ-spouse"/>
+                    <SimplePredicate field="education_num" operator="greaterOrEqual" value="8.0"/>
+                    <SimplePredicate field="education_num" operator="lessOrEqual" value="12.0"/>
+                    <SimplePredicate field="age" operator="greaterOrEqual" value="42.0"/>
+                    <SimplePredicate field="workclass" operator="equal" value="Federal-gov"/>
+                    <SimplePredicate field="fnlwgt" operator="lessOrEqual" value="293196.0"/>
+                    <SimplePredicate field="fnlwgt" operator="greaterOrEqual" value="211128.0"/>
+                </CompoundPredicate>
+            </SimpleRule>
+            <SimpleRule id="[marital_status == Married-civ-spouse] ^ [education_num &gt;= 9.0] ^ [age &gt;= 36.0] ^ [education_num &lt;= 11.0] ^ [occupation == Exec-managerial]" score="&gt;50K" recordCount="15081" nbCorrect="11393" confidence="0.6234096692111959" weight="0.6234096692111959">
+                <CompoundPredicate booleanOperator="and">
+                    <SimplePredicate field="marital_status" operator="equal" value="Married-civ-spouse"/>
+                    <SimplePredicate field="education_num" operator="greaterOrEqual" value="9.0"/>
+                    <SimplePredicate field="age" operator="greaterOrEqual" value="36.0"/>
+                    <SimplePredicate field="education_num" operator="lessOrEqual" value="11.0"/>
+                    <SimplePredicate field="occupation" operator="equal" value="Exec-managerial"/>
+                </CompoundPredicate>
+            </SimpleRule>
+            <SimpleRule id="[marital_status == Married-civ-spouse] ^ [age &gt;= 37.0] ^ [education_num &lt;= 12.0] ^ [occupation == Adm-clerical] ^ [relationship == Wife] ^ [education_num &gt;= 10.0] ^ [age &lt;= 42.0]" score="&gt;50K" recordCount="15081" nbCorrect="11298" confidence="0.55" weight="0.55">
                 <CompoundPredicate booleanOperator="and">
                     <SimplePredicate field="marital_status" operator="equal" value="Married-civ-spouse"/>
                     <SimplePredicate field="age" operator="greaterOrEqual" value="37.0"/>
                     <SimplePredicate field="education_num" operator="lessOrEqual" value="12.0"/>
-                    <SimplePredicate field="age" operator="lessOrEqual" value="47.0"/>
+                    <SimplePredicate field="occupation" operator="equal" value="Adm-clerical"/>
+                    <SimplePredicate field="relationship" operator="equal" value="Wife"/>
                     <SimplePredicate field="education_num" operator="greaterOrEqual" value="10.0"/>
-                    <SimplePredicate field="occupation" operator="equal" value="Sales"/>
-                    <SimplePredicate field="fnlwgt" operator="greaterOrEqual" value="131827.0"/>
+                    <SimplePredicate field="age" operator="lessOrEqual" value="42.0"/>
                 </CompoundPredicate>
             </SimpleRule>
-            <SimpleRule id="[marital_status == Married-civ-spouse] ^ [education_num &gt;= 13.0]" score="&gt;50K" recordCount="15081" nbCorrect="12283" confidence="0.7355608591885442" weight="0.7355608591885442">
+            <SimpleRule id="[marital_status == Married-civ-spouse] ^ [education_num &gt;= 9.0] ^ [education_num &lt;= 11.0] ^ [hours_per_week &gt;= 40.0] ^ [age &gt;= 45.0] ^ [fnlwgt &gt;= 235639.0] ^ [occupation == Craft-repair] ^ [education == Some-college]" score="&gt;50K" recordCount="15081" nbCorrect="11301" confidence="0.6086956521739131" weight="0.6086956521739131">
+                <CompoundPredicate booleanOperator="and">
+                    <SimplePredicate field="marital_status" operator="equal" value="Married-civ-spouse"/>
+                    <SimplePredicate field="education_num" operator="greaterOrEqual" value="9.0"/>
+                    <SimplePredicate field="education_num" operator="lessOrEqual" value="11.0"/>
+                    <SimplePredicate field="hours_per_week" operator="greaterOrEqual" value="40.0"/>
+                    <SimplePredicate field="age" operator="greaterOrEqual" value="45.0"/>
+                    <SimplePredicate field="fnlwgt" operator="greaterOrEqual" value="235639.0"/>
+                    <SimplePredicate field="occupation" operator="equal" value="Craft-repair"/>
+                    <SimplePredicate field="education" operator="equal" value="Some-college"/>
+                </CompoundPredicate>
+            </SimpleRule>
+            <SimpleRule id="[marital_status == Married-civ-spouse] ^ [education_num &gt;= 10.0] ^ [age &gt;= 36.0] ^ [capital_gain &gt;= 6849.0]" score="&gt;50K" recordCount="15081" nbCorrect="11656" confidence="0.9918032786885246" weight="0.9918032786885246">
+                <CompoundPredicate booleanOperator="and">
+                    <SimplePredicate field="marital_status" operator="equal" value="Married-civ-spouse"/>
+                    <SimplePredicate field="education_num" operator="greaterOrEqual" value="10.0"/>
+                    <SimplePredicate field="age" operator="greaterOrEqual" value="36.0"/>
+                    <SimplePredicate field="capital_gain" operator="greaterOrEqual" value="6849.0"/>
+                </CompoundPredicate>
+            </SimpleRule>
+            <SimpleRule id="[marital_status == Married-civ-spouse] ^ [education_num &gt;= 13.0] ^ [hours_per_week &gt;= 35.0] ^ [occupation == Exec-managerial] ^ [fnlwgt &lt;= 162442.0] ^ [age &lt;= 55.0]" score="&gt;50K" recordCount="15081" nbCorrect="11447" confidence="0.8185654008438819" weight="0.8185654008438819">
                 <CompoundPredicate booleanOperator="and">
                     <SimplePredicate field="marital_status" operator="equal" value="Married-civ-spouse"/>
                     <SimplePredicate field="education_num" operator="greaterOrEqual" value="13.0"/>
+                    <SimplePredicate field="hours_per_week" operator="greaterOrEqual" value="35.0"/>
+                    <SimplePredicate field="occupation" operator="equal" value="Exec-managerial"/>
+                    <SimplePredicate field="fnlwgt" operator="lessOrEqual" value="162442.0"/>
+                    <SimplePredicate field="age" operator="lessOrEqual" value="55.0"/>
                 </CompoundPredicate>
             </SimpleRule>
-            <SimpleRule id="[marital_status == Married-civ-spouse] ^ [capital_gain &gt;= 5178.0]" score="&gt;50K" recordCount="15081" nbCorrect="11863" confidence="0.9913344887348353" weight="0.9913344887348353">
+            <SimpleRule id="[marital_status == Married-civ-spouse] ^ [education_num &gt;= 9.0] ^ [education_num &lt;= 11.0] ^ [age &gt;= 42.0] ^ [fnlwgt &lt;= 192755.0] ^ [age &lt;= 48.0] ^ [fnlwgt &gt;= 190511.0]" score="&gt;50K" recordCount="15081" nbCorrect="11297" confidence="0.5384615384615384" weight="0.5384615384615384">
+                <CompoundPredicate booleanOperator="and">
+                    <SimplePredicate field="marital_status" operator="equal" value="Married-civ-spouse"/>
+                    <SimplePredicate field="education_num" operator="greaterOrEqual" value="9.0"/>
+                    <SimplePredicate field="education_num" operator="lessOrEqual" value="11.0"/>
+                    <SimplePredicate field="age" operator="greaterOrEqual" value="42.0"/>
+                    <SimplePredicate field="fnlwgt" operator="lessOrEqual" value="192755.0"/>
+                    <SimplePredicate field="age" operator="lessOrEqual" value="48.0"/>
+                    <SimplePredicate field="fnlwgt" operator="greaterOrEqual" value="190511.0"/>
+                </CompoundPredicate>
+            </SimpleRule>
+            <SimpleRule id="[marital_status == Married-civ-spouse] ^ [age &gt;= 36.0] ^ [hours_per_week &gt;= 35.0] ^ [education_num &gt;= 13.0]" score="&gt;50K" recordCount="15081" nbCorrect="12133" confidence="0.7872340425531915" weight="0.7872340425531915">
+                <CompoundPredicate booleanOperator="and">
+                    <SimplePredicate field="marital_status" operator="equal" value="Married-civ-spouse"/>
+                    <SimplePredicate field="age" operator="greaterOrEqual" value="36.0"/>
+                    <SimplePredicate field="hours_per_week" operator="greaterOrEqual" value="35.0"/>
+                    <SimplePredicate field="education_num" operator="greaterOrEqual" value="13.0"/>
+                </CompoundPredicate>
+            </SimpleRule>
+            <SimpleRule id="[marital_status == Married-civ-spouse] ^ [education_num &gt;= 9.0] ^ [age &gt;= 32.0] ^ [education_num &lt;= 11.0] ^ [occupation == Sales] ^ [hours_per_week &gt;= 51.0]" score="&gt;50K" recordCount="15081" nbCorrect="11291" confidence="0.47191011235955055" weight="0.47191011235955055">
+                <CompoundPredicate booleanOperator="and">
+                    <SimplePredicate field="marital_status" operator="equal" value="Married-civ-spouse"/>
+                    <SimplePredicate field="education_num" operator="greaterOrEqual" value="9.0"/>
+                    <SimplePredicate field="age" operator="greaterOrEqual" value="32.0"/>
+                    <SimplePredicate field="education_num" operator="lessOrEqual" value="11.0"/>
+                    <SimplePredicate field="occupation" operator="equal" value="Sales"/>
+                    <SimplePredicate field="hours_per_week" operator="greaterOrEqual" value="51.0"/>
+                </CompoundPredicate>
+            </SimpleRule>
+            <SimpleRule id="[marital_status == Married-civ-spouse] ^ [capital_gain &gt;= 5178.0] ^ [age &lt;= 60.0]" score="&gt;50K" recordCount="15081" nbCorrect="11806" confidence="0.9961089494163424" weight="0.9961089494163424">
                 <CompoundPredicate booleanOperator="and">
                     <SimplePredicate field="marital_status" operator="equal" value="Married-civ-spouse"/>
                     <SimplePredicate field="capital_gain" operator="greaterOrEqual" value="5178.0"/>
+                    <SimplePredicate field="age" operator="lessOrEqual" value="60.0"/>
                 </CompoundPredicate>
             </SimpleRule>
-            <SimpleRule id="[marital_status == Married-civ-spouse] ^ [education_num &lt;= 12.0] ^ [capital_loss &gt;= 1741.0]" score="&gt;50K" recordCount="15081" nbCorrect="11370" confidence="0.6968085106382979" weight="0.6968085106382979">
+            <SimpleRule id="[marital_status == Married-civ-spouse] ^ [capital_loss &gt;= 1741.0] ^ [capital_loss &lt;= 1887.0]" score="&gt;50K" recordCount="15081" nbCorrect="11398" confidence="0.9811320754716981" weight="0.9811320754716981">
                 <CompoundPredicate booleanOperator="and">
                     <SimplePredicate field="marital_status" operator="equal" value="Married-civ-spouse"/>
-                    <SimplePredicate field="education_num" operator="lessOrEqual" value="12.0"/>
                     <SimplePredicate field="capital_loss" operator="greaterOrEqual" value="1741.0"/>
-                </CompoundPredicate>
-            </SimpleRule>
-            <SimpleRule id="[marital_status == Married-civ-spouse] ^ [education_num &gt;= 10.0] ^ [fnlwgt &gt;= 118088.0] ^ [occupation == Exec-managerial] ^ [hours_per_week &gt;= 41.0]" score="&gt;50K" recordCount="15081" nbCorrect="11535" confidence="0.8103896103896104" weight="0.8103896103896104">
-                <CompoundPredicate booleanOperator="and">
-                    <SimplePredicate field="marital_status" operator="equal" value="Married-civ-spouse"/>
-                    <SimplePredicate field="education_num" operator="greaterOrEqual" value="10.0"/>
-                    <SimplePredicate field="fnlwgt" operator="greaterOrEqual" value="118088.0"/>
-                    <SimplePredicate field="occupation" operator="equal" value="Exec-managerial"/>
-                    <SimplePredicate field="hours_per_week" operator="greaterOrEqual" value="41.0"/>
+                    <SimplePredicate field="capital_loss" operator="lessOrEqual" value="1887.0"/>
                 </CompoundPredicate>
             </SimpleRule>
         </RuleSet>

--- a/tests/rule_induction/trxf/pmml_export/resources/adult_py36.pmml
+++ b/tests/rule_induction/trxf/pmml_export/resources/adult_py36.pmml
@@ -1,0 +1,217 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<PMML xmlns="http://www.dmg.org/PMML-4_4" version="4.4.1">
+    <Header copyright="Copyright IBM Corp, exported to PMML by Nyoka (c) 2022 Software AG" description="Default description">
+        <Application name="SimpleRuleSetExport" version="0.0.1"/>
+        <Timestamp>1970-01-01 00:00:00+00:00</Timestamp>
+    </Header>
+    <DataDictionary numberOfFields="14">
+        <DataField name="age" optype="continuous" dataType="double"/>
+        <DataField name="workclass" optype="categorical" dataType="string">
+            <Value value="Private"/>
+            <Value value="State-gov"/>
+            <Value value="Self-emp-not-inc"/>
+            <Value value="Local-gov"/>
+            <Value value="Federal-gov"/>
+            <Value value="Self-emp-inc"/>
+            <Value value="Without-pay"/>
+        </DataField>
+        <DataField name="fnlwgt" optype="continuous" dataType="double"/>
+        <DataField name="education" optype="categorical" dataType="string">
+            <Value value="HS-grad"/>
+            <Value value="10th"/>
+            <Value value="Bachelors"/>
+            <Value value="Assoc-acdm"/>
+            <Value value="Some-college"/>
+            <Value value="Doctorate"/>
+            <Value value="Prof-school"/>
+            <Value value="9th"/>
+            <Value value="Assoc-voc"/>
+            <Value value="Masters"/>
+            <Value value="7th-8th"/>
+            <Value value="11th"/>
+            <Value value="1st-4th"/>
+            <Value value="5th-6th"/>
+            <Value value="12th"/>
+            <Value value="Preschool"/>
+        </DataField>
+        <DataField name="education_num" optype="continuous" dataType="double"/>
+        <DataField name="marital_status" optype="categorical" dataType="string">
+            <Value value="Married-civ-spouse"/>
+            <Value value="Divorced"/>
+            <Value value="Never-married"/>
+            <Value value="Widowed"/>
+            <Value value="Separated"/>
+            <Value value="Married-spouse-absent"/>
+            <Value value="Married-AF-spouse"/>
+        </DataField>
+        <DataField name="occupation" optype="categorical" dataType="string">
+            <Value value="Transport-moving"/>
+            <Value value="Craft-repair"/>
+            <Value value="Sales"/>
+            <Value value="Adm-clerical"/>
+            <Value value="Prof-specialty"/>
+            <Value value="Other-service"/>
+            <Value value="Exec-managerial"/>
+            <Value value="Farming-fishing"/>
+            <Value value="Machine-op-inspct"/>
+            <Value value="Handlers-cleaners"/>
+            <Value value="Protective-serv"/>
+            <Value value="Tech-support"/>
+            <Value value="Priv-house-serv"/>
+            <Value value="Armed-Forces"/>
+        </DataField>
+        <DataField name="relationship" optype="categorical" dataType="string">
+            <Value value="Husband"/>
+            <Value value="Not-in-family"/>
+            <Value value="Wife"/>
+            <Value value="Own-child"/>
+            <Value value="Unmarried"/>
+            <Value value="Other-relative"/>
+        </DataField>
+        <DataField name="race" optype="categorical" dataType="string">
+            <Value value="White"/>
+            <Value value="Black"/>
+            <Value value="Other"/>
+            <Value value="Asian-Pac-Islander"/>
+            <Value value="Amer-Indian-Eskimo"/>
+        </DataField>
+        <DataField name="sex" optype="categorical" dataType="string">
+            <Value value="Male"/>
+            <Value value="Female"/>
+        </DataField>
+        <DataField name="capital_gain" optype="continuous" dataType="double"/>
+        <DataField name="capital_loss" optype="continuous" dataType="double"/>
+        <DataField name="hours_per_week" optype="continuous" dataType="double"/>
+        <DataField name="native_country" optype="categorical" dataType="string">
+            <Value value="United-States"/>
+            <Value value="Portugal"/>
+            <Value value="Cuba"/>
+            <Value value="Mexico"/>
+            <Value value="France"/>
+            <Value value="Jamaica"/>
+            <Value value="Haiti"/>
+            <Value value="Honduras"/>
+            <Value value="India"/>
+            <Value value="Dominican-Republic"/>
+            <Value value="Outlying-US(Guam-USVI-etc)"/>
+            <Value value="South"/>
+            <Value value="Scotland"/>
+            <Value value="Italy"/>
+            <Value value="Germany"/>
+            <Value value="Philippines"/>
+            <Value value="Vietnam"/>
+            <Value value="El-Salvador"/>
+            <Value value="Nicaragua"/>
+            <Value value="China"/>
+            <Value value="Trinadad&amp;Tobago"/>
+            <Value value="Puerto-Rico"/>
+            <Value value="Japan"/>
+            <Value value="Iran"/>
+            <Value value="Guatemala"/>
+            <Value value="England"/>
+            <Value value="Poland"/>
+            <Value value="Canada"/>
+            <Value value="Cambodia"/>
+            <Value value="Greece"/>
+            <Value value="Thailand"/>
+            <Value value="Ireland"/>
+            <Value value="Hong"/>
+            <Value value="Taiwan"/>
+            <Value value="Ecuador"/>
+            <Value value="Peru"/>
+            <Value value="Yugoslavia"/>
+            <Value value="Columbia"/>
+            <Value value="Hungary"/>
+            <Value value="Laos"/>
+            <Value value="Holand-Netherlands"/>
+        </DataField>
+    </DataDictionary>
+    <RuleSetModel functionName="classification" algorithmName="RuleSet">
+        <MiningSchema>
+            <MiningField name="marital_status" usageType="active"/>
+            <MiningField name="education_num" usageType="active"/>
+            <MiningField name="hours_per_week" usageType="active"/>
+            <MiningField name="education" usageType="active"/>
+            <MiningField name="age" usageType="active"/>
+            <MiningField name="occupation" usageType="active"/>
+            <MiningField name="fnlwgt" usageType="active"/>
+            <MiningField name="capital_gain" usageType="active"/>
+            <MiningField name="capital_loss" usageType="active"/>
+        </MiningSchema>
+        <RuleSet defaultScore="&lt;=50K">
+            <RuleSelectionMethod criterion="weightedMax"/>
+            <SimpleRule id="[marital_status == Married-civ-spouse] ^ [education_num &lt;= 12.0] ^ [education_num &gt;= 8.0] ^ [hours_per_week &gt;= 38.0] ^ [education == Some-college] ^ [age &lt;= 57.0] ^ [hours_per_week &lt;= 45.0] ^ [age &gt;= 48.0]" score="&gt;50K" recordCount="15081" nbCorrect="11329" confidence="0.609271523178808" weight="0.609271523178808">
+                <CompoundPredicate booleanOperator="and">
+                    <SimplePredicate field="marital_status" operator="equal" value="Married-civ-spouse"/>
+                    <SimplePredicate field="education_num" operator="lessOrEqual" value="12.0"/>
+                    <SimplePredicate field="education_num" operator="greaterOrEqual" value="8.0"/>
+                    <SimplePredicate field="hours_per_week" operator="greaterOrEqual" value="38.0"/>
+                    <SimplePredicate field="education" operator="equal" value="Some-college"/>
+                    <SimplePredicate field="age" operator="lessOrEqual" value="57.0"/>
+                    <SimplePredicate field="hours_per_week" operator="lessOrEqual" value="45.0"/>
+                    <SimplePredicate field="age" operator="greaterOrEqual" value="48.0"/>
+                </CompoundPredicate>
+            </SimpleRule>
+            <SimpleRule id="[marital_status == Married-civ-spouse] ^ [education_num &lt;= 12.0] ^ [age &gt;= 37.0] ^ [occupation == Tech-support]" score="&gt;50K" recordCount="15081" nbCorrect="11323" confidence="0.684931506849315" weight="0.684931506849315">
+                <CompoundPredicate booleanOperator="and">
+                    <SimplePredicate field="marital_status" operator="equal" value="Married-civ-spouse"/>
+                    <SimplePredicate field="education_num" operator="lessOrEqual" value="12.0"/>
+                    <SimplePredicate field="age" operator="greaterOrEqual" value="37.0"/>
+                    <SimplePredicate field="occupation" operator="equal" value="Tech-support"/>
+                </CompoundPredicate>
+            </SimpleRule>
+            <SimpleRule id="[marital_status == Married-civ-spouse] ^ [education_num &lt;= 12.0] ^ [education_num &gt;= 9.0] ^ [hours_per_week &gt;= 40.0] ^ [age &gt;= 42.0] ^ [education == HS-grad] ^ [age &lt;= 53.0] ^ [fnlwgt &gt;= 154227.0] ^ [fnlwgt &lt;= 163948.0]" score="&gt;50K" recordCount="15081" nbCorrect="11287" confidence="0.3448275862068966" weight="0.3448275862068966">
+                <CompoundPredicate booleanOperator="and">
+                    <SimplePredicate field="marital_status" operator="equal" value="Married-civ-spouse"/>
+                    <SimplePredicate field="education_num" operator="lessOrEqual" value="12.0"/>
+                    <SimplePredicate field="education_num" operator="greaterOrEqual" value="9.0"/>
+                    <SimplePredicate field="hours_per_week" operator="greaterOrEqual" value="40.0"/>
+                    <SimplePredicate field="age" operator="greaterOrEqual" value="42.0"/>
+                    <SimplePredicate field="education" operator="equal" value="HS-grad"/>
+                    <SimplePredicate field="age" operator="lessOrEqual" value="53.0"/>
+                    <SimplePredicate field="fnlwgt" operator="greaterOrEqual" value="154227.0"/>
+                    <SimplePredicate field="fnlwgt" operator="lessOrEqual" value="163948.0"/>
+                </CompoundPredicate>
+            </SimpleRule>
+            <SimpleRule id="[marital_status == Married-civ-spouse] ^ [age &gt;= 37.0] ^ [education_num &lt;= 12.0] ^ [age &lt;= 47.0] ^ [education_num &gt;= 10.0] ^ [occupation == Sales] ^ [fnlwgt &gt;= 131827.0]" score="&gt;50K" recordCount="15081" nbCorrect="11300" confidence="0.5333333333333333" weight="0.5333333333333333">
+                <CompoundPredicate booleanOperator="and">
+                    <SimplePredicate field="marital_status" operator="equal" value="Married-civ-spouse"/>
+                    <SimplePredicate field="age" operator="greaterOrEqual" value="37.0"/>
+                    <SimplePredicate field="education_num" operator="lessOrEqual" value="12.0"/>
+                    <SimplePredicate field="age" operator="lessOrEqual" value="47.0"/>
+                    <SimplePredicate field="education_num" operator="greaterOrEqual" value="10.0"/>
+                    <SimplePredicate field="occupation" operator="equal" value="Sales"/>
+                    <SimplePredicate field="fnlwgt" operator="greaterOrEqual" value="131827.0"/>
+                </CompoundPredicate>
+            </SimpleRule>
+            <SimpleRule id="[marital_status == Married-civ-spouse] ^ [education_num &gt;= 13.0]" score="&gt;50K" recordCount="15081" nbCorrect="12283" confidence="0.7355608591885442" weight="0.7355608591885442">
+                <CompoundPredicate booleanOperator="and">
+                    <SimplePredicate field="marital_status" operator="equal" value="Married-civ-spouse"/>
+                    <SimplePredicate field="education_num" operator="greaterOrEqual" value="13.0"/>
+                </CompoundPredicate>
+            </SimpleRule>
+            <SimpleRule id="[marital_status == Married-civ-spouse] ^ [capital_gain &gt;= 5178.0]" score="&gt;50K" recordCount="15081" nbCorrect="11863" confidence="0.9913344887348353" weight="0.9913344887348353">
+                <CompoundPredicate booleanOperator="and">
+                    <SimplePredicate field="marital_status" operator="equal" value="Married-civ-spouse"/>
+                    <SimplePredicate field="capital_gain" operator="greaterOrEqual" value="5178.0"/>
+                </CompoundPredicate>
+            </SimpleRule>
+            <SimpleRule id="[marital_status == Married-civ-spouse] ^ [education_num &lt;= 12.0] ^ [capital_loss &gt;= 1741.0]" score="&gt;50K" recordCount="15081" nbCorrect="11370" confidence="0.6968085106382979" weight="0.6968085106382979">
+                <CompoundPredicate booleanOperator="and">
+                    <SimplePredicate field="marital_status" operator="equal" value="Married-civ-spouse"/>
+                    <SimplePredicate field="education_num" operator="lessOrEqual" value="12.0"/>
+                    <SimplePredicate field="capital_loss" operator="greaterOrEqual" value="1741.0"/>
+                </CompoundPredicate>
+            </SimpleRule>
+            <SimpleRule id="[marital_status == Married-civ-spouse] ^ [education_num &gt;= 10.0] ^ [fnlwgt &gt;= 118088.0] ^ [occupation == Exec-managerial] ^ [hours_per_week &gt;= 41.0]" score="&gt;50K" recordCount="15081" nbCorrect="11535" confidence="0.8103896103896104" weight="0.8103896103896104">
+                <CompoundPredicate booleanOperator="and">
+                    <SimplePredicate field="marital_status" operator="equal" value="Married-civ-spouse"/>
+                    <SimplePredicate field="education_num" operator="greaterOrEqual" value="10.0"/>
+                    <SimplePredicate field="fnlwgt" operator="greaterOrEqual" value="118088.0"/>
+                    <SimplePredicate field="occupation" operator="equal" value="Exec-managerial"/>
+                    <SimplePredicate field="hours_per_week" operator="greaterOrEqual" value="41.0"/>
+                </CompoundPredicate>
+            </SimpleRule>
+        </RuleSet>
+    </RuleSetModel>
+</PMML>

--- a/tests/rule_induction/trxf/pmml_export/resources/toto.pmml
+++ b/tests/rule_induction/trxf/pmml_export/resources/toto.pmml
@@ -6,7 +6,9 @@
     </Header>
     <DataDictionary numberOfFields="4">
         <DataField name="toto0" optype="continuous" dataType="double"/>
-        <DataField name="toto1" optype="categorical" dataType="string"/>
+        <DataField name="toto1" optype="categorical" dataType="string">
+            <Value value="foo"/>
+        </DataField>
         <DataField name="toto2" optype="categorical" dataType="boolean"/>
         <DataField name="toto3" optype="ordinal" dataType="integer"/>
     </DataDictionary>

--- a/tests/rule_induction/trxf/pmml_export/test_pmml_exporter.py
+++ b/tests/rule_induction/trxf/pmml_export/test_pmml_exporter.py
@@ -1,5 +1,6 @@
 import datetime
 import os
+import sys
 from unittest import TestCase
 
 import pandas as pd
@@ -129,7 +130,8 @@ class TestPmmlExporter(TestCase):
         reader.load_data_dictionary(x_test)
         serializer = NyokaSerializer(TIMESTAMP)
         exporter = PmmlExporter(reader, serializer)
-        with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'resources/adult.pmml')) as file:
+        filename = 'adult.pmml' if sys.version_info[1] > 6 else 'adult_py36.pmml'
+        with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), 'resources', filename)) as file:
             expected = file.read()
         actual = exporter.export(classifier)
         self.assertEqual(expected, actual)

--- a/tests/rule_induction/trxf/pmml_export/test_pmml_exporter.py
+++ b/tests/rule_induction/trxf/pmml_export/test_pmml_exporter.py
@@ -2,7 +2,6 @@ import datetime
 import os
 from unittest import TestCase
 
-import numpy as np
 import pandas as pd
 from sklearn.model_selection import train_test_split
 
@@ -43,11 +42,11 @@ class TestPmmlExporter(TestCase):
         data = pd.read_csv('https://archive.ics.uci.edu/ml/machine-learning-databases/iris/iris.data',
                            header=None,
                            names=['sepal_length', 'sepal_width', 'petal_length', 'petal_width', 'class_name'],
-                           dtype={'sepal_length': np.float,
-                                  'sepal_width': np.float,
-                                  'petal_length': np.float,
-                                  'petal_width': np.float,
-                                  'class_name': np.str})
+                           dtype={'sepal_length': float,
+                                  'sepal_width': float,
+                                  'petal_length': float,
+                                  'petal_width': float,
+                                  'class_name': str})
 
         col_names = ['sepal_length', 'sepal_width', 'petal_length', 'petal_width', 'class_name']
 
@@ -75,20 +74,20 @@ class TestPmmlExporter(TestCase):
         self.assertEqual(expected, actual)
 
     def test_ripper_adult(self):
-        data_type = {'age': np.float,
+        data_type = {'age': float,
                      'workclass': str,
-                     'fnlwgt': np.float,
+                     'fnlwgt': float,
                      'education': str,
-                     'education-num': np.float,
+                     'education-num': float,
                      'marital-status': str,
                      'occupation': str,
                      'relationship': str,
                      'race': str,
                      'sex': str,
-                     'capital-gain': np.float,
-                     'capital-loss': np.float,
+                     'capital-gain': float,
+                     'capital-loss': float,
                      'native-country': str,
-                     'hours-per-week': np.float,
+                     'hours-per-week': float,
                      'label': str}
 
         col_names = ['age', 'workclass', 'fnlwgt', 'education',
@@ -140,13 +139,13 @@ class TestPmmlExporter(TestCase):
                            header=None,
                            delimiter='\t',
                            names=['X1', 'X2', 'X3', 'X4', 'X5', 'X6', 'X7', 'Y'],
-                           dtype={'X1': np.float,
-                                  'X2': np.float,
-                                  'X3': np.float,
-                                  'X4': np.float,
-                                  'X5': np.float,
-                                  'X6': np.float,
-                                  'X7': np.float,
+                           dtype={'X1': float,
+                                  'X2': float,
+                                  'X3': float,
+                                  'X4': float,
+                                  'X5': float,
+                                  'X6': float,
+                                  'X7': float,
                                   'Y': str})
 
         x = data.loc[:, ['X1', 'X2', 'X3', 'X4', 'X5', 'X6', 'X7']]

--- a/tests/rule_induction/trxf/utilities.py
+++ b/tests/rule_induction/trxf/utilities.py
@@ -6,10 +6,11 @@ from aix360.algorithms.rule_induction.trxf.pmml_export import models
 from aix360.algorithms.rule_induction.trxf.pmml_export.models import DataDictionary, DataField, OpType, DataType, \
     MiningSchema, MiningField, MiningFieldUsageType, RuleSet, SimpleRule, CompoundPredicate, SimplePredicate, Operator, \
     BooleanOperator
+from aix360.algorithms.rule_induction.trxf.pmml_export.models.data_dictionary import Value
 
 DATA_DICTIONARY = DataDictionary(
     dataFields=[DataField(name='toto0', optype=OpType.continuous, dataType=DataType.double),
-                DataField(name='toto1', optype=OpType.categorical, dataType=DataType.string),
+                DataField(name='toto1', optype=OpType.categorical, dataType=DataType.string, values=[Value('foo')]),
                 DataField(name='toto2', optype=OpType.categorical, dataType=DataType.boolean),
                 DataField(name='toto3', optype=OpType.ordinal, dataType=DataType.integer)]
 )


### PR DESCRIPTION
* Categorical datafields with str type now includes the list of possible/legal values in the PMML file.
* Fixed one test that was failing in python 3.8 in rule induction

More details in the individual commit messages.

Edit: It was 3.8 not 3.7 