### PR TITLE
Minimal fixes to CI

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -381,7 +381,10 @@ jobs:
         run: pip3 install pytest nbmake wheel --upgrade setuptools
 
       - name: Step 5 - Install aix360 with imd algorithm related dependencies
-        run: pip3 install .[imd]
+        run: |
+          export CFLAGS="-I$(brew --prefix graphviz)/include"
+          export LDFLAGS="-L$(brew --prefix graphviz)/lib"
+          pip3 install .[imd]
 
       - name: Step 5 - Test IMD
         run: python ./tests/imd/test_imd.py

--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -19,16 +19,16 @@ jobs:
     strategy:
       matrix:
         #os: [ubuntu-18.04, ubuntu-latest, macos-latest, windows-latest]
-        os: [ubuntu-20.04, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.6"]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Step 1 - checkout aix360 repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Step 2 - set up python version
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "${{ matrix.python-version }}"
 
@@ -51,16 +51,16 @@ jobs:
     strategy:
       matrix:
         #os: [ubuntu-18.04, ubuntu-latest, macos-latest, windows-latest]
-        os: [ubuntu-20.04, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.10"]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Step 1 - checkout aix360 repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Step 2 - set up python version
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "${{ matrix.python-version }}"
 
@@ -80,16 +80,16 @@ jobs:
     strategy:
       matrix:
         #os: [ubuntu-18.04, ubuntu-latest, macos-latest, windows-latest]
-        os: [ubuntu-20.04, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.10"]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Step 1 - checkout aix360 repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Step 2 - set up python version
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "${{ matrix.python-version }}"
 
@@ -110,16 +110,16 @@ jobs:
     strategy:
       matrix:
         #os: [ubuntu-18.04, ubuntu-latest, macos-latest, windows-latest]
-        os: [ubuntu-20.04, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.10"]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Step 1 - checkout aix360 repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Step 2 - set up python version
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "${{ matrix.python-version }}"
 
@@ -139,16 +139,16 @@ jobs:
     strategy:
       matrix:
         #os: [ubuntu-18.04, ubuntu-latest, macos-latest, windows-latest]
-        os: [ubuntu-20.04, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.10"]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Step 1 - checkout aix360 repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Step 2 - set up python version
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "${{ matrix.python-version }}"
 
@@ -168,16 +168,16 @@ jobs:
     strategy:
       matrix:
         #os: [ubuntu-18.04, ubuntu-latest, macos-latest, windows-latest]
-        os: [ubuntu-20.04, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.10"]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Step 1 - checkout aix360 repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Step 2 - set up python version
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "${{ matrix.python-version }}"
 
@@ -200,16 +200,16 @@ jobs:
     strategy:
       matrix:
         #os: [ubuntu-18.04, ubuntu-latest, macos-latest, windows-latest]
-        os: [ubuntu-20.04, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.10"]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Step 1 - checkout aix360 repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Step 2 - set up python version
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "${{ matrix.python-version }}"
 
@@ -229,16 +229,16 @@ jobs:
     strategy:
       matrix:
         #os: [ubuntu-18.04, ubuntu-latest, macos-latest, windows-latest]
-        os: [ubuntu-20.04, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.10"]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Step 1 - checkout aix360 repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Step 2 - set up python version
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "${{ matrix.python-version }}"
 
@@ -263,16 +263,16 @@ jobs:
     runs-on: "${{ matrix.os }}"
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.10"]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Step 1 - checkout aix360 repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Step 2 - set up python version
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "${{ matrix.python-version }}"
 
@@ -291,16 +291,16 @@ jobs:
     runs-on: "${{ matrix.os }}"
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.10"]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Step 1 - checkout aix360 repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Step 2 - set up python version
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "${{ matrix.python-version }}"
 
@@ -328,16 +328,16 @@ jobs:
       fail-fast: false
       matrix:
         #        os: [ubuntu-18.04, ubuntu-latest, macos-latest, windows-latest]
-        os: [ubuntu-20.04]
+        os: [ubuntu-latest]
         python-version: ["3.10"]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Step 1 - checkout aix360 repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Step 2 - set up python version
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "${{ matrix.python-version }}"
 
@@ -367,10 +367,10 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Step 1 - checkout aix360 repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Step 2 - set up python version
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "${{ matrix.python-version }}"
 
@@ -396,16 +396,16 @@ jobs:
       fail-fast: false
       matrix:
         #        os: [ubuntu-18.04, ubuntu-latest, macos-latest, windows-latest]
-        os: [ubuntu-20.04, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.10"]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Step 1 - checkout aix360 repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Step 2 - set up python version
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "${{ matrix.python-version }}"
 
@@ -427,16 +427,16 @@ jobs:
     runs-on: "${{ matrix.os }}"
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.10"]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Step 1 - checkout aix360 repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Step 2 - set up python version
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "${{ matrix.python-version }}"
 
@@ -455,16 +455,16 @@ jobs:
     strategy:
       matrix:
         #os: [ubuntu-18.04, ubuntu-latest, macos-latest, windows-latest]
-        os: [ubuntu-20.04, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.10"]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Step 1 - checkout aix360 repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Step 2 - set up python version
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "${{ matrix.python-version }}"
 

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ extra_requires = {
         "scipy>=0.17,<=1.10.1",
         "scikit-learn<1.2.0",
         "cvxpy>=1.1",
+        "ecos",
         "numpy<=1.24.3",
     ],
     "profwt": [

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ extra_requires = {
     "rule_induction": [
         "matplotlib",
         "numba",
+        "numpy<2.0.0",
         "pandas<2.0.0",
         "scikit-learn",
         "nyoka",
@@ -86,6 +87,7 @@ extra_requires = {
         "tensorflow==2.9.3",
     ],
     "tsice": [
+        "numpy<2.0.0",
         "pandas<2.0.0",
         "scipy",
         "plotly",  # required for units
@@ -94,6 +96,7 @@ extra_requires = {
         "requests",  # required for dataset and units
     ],
     "tssaliency": [
+        "numpy<2.0.0",
         "pandas<2.0.0",
         "requests",  # required for dataset and units
     ],
@@ -107,6 +110,7 @@ extra_requires = {
         "pygraphviz",  # for creating graph visualization
     ],
     "tslime": [
+        "numpy<2.0.0",
         "pandas<2.0.0",
         "scipy",
         "requests",  # required for dataset and units


### PR DESCRIPTION
## Summary

Infrastructure and dependency fixes to get CI passing again.

### Fixed
- Replace retired `ubuntu-20.04` runners with `ubuntu-latest` across all CI jobs
- Upgrade `actions/checkout` from v3 to v4 and `actions/setup-python` from v4 to v5 (Node.js 20 deprecation)
- Add `ecos` as explicit dependency for the `rbm` extra (cvxpy 1.4+ no longer bundles it)
- Set CFLAGS/LDFLAGS for pygraphviz build on macOS (Homebrew headers not in default search path on arm64)
- Pin `numpy<2.0.0` for `rule_induction`, `tsice`, `tssaliency`, and `tslime` extras (binary incompatibility with `pandas<2.0.0`)

### Remaining failures (not addressed in this PR)
- **`build-cem-on-py36`** — Python 3.6 is EOL and unavailable on current runners. Job needs to be removed or upgraded.
- **`build-protodash`** — `xport` package uses `pkg_resources.DistributionNotFound` which was removed from newer setuptools. Needs `xport` upgrade or replacement.
- **`build-nncontrastive`** — Pins `tensorflow==2.9.3` which is unavailable on current platforms/Python versions. Needs version bump (2.13+ available for Py 3.10).
- **`build-cofrnet` (Windows only)** — PyTorch DLL initialization failure (`c10.dll`). Passes on Ubuntu and macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)